### PR TITLE
Allow custom timedeltas for throttling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,12 +288,12 @@ You can define rules per endpoint using regex:
 ```py
 TWO_REQS_FOR_ANY_ENDPOINT_RULE = ThrottleRule(
   url_pattern=r".*",
-  requests_per_second_limit=2
+  max_requests=2
 )
 
 TEN_REQS_FOR_ANY_POKEMON_ENDPOINT_RULE = ThrottleRule(
   url_pattern=r".*\/pokemon\/.*",
-  requests_per_second_limit=10
+  max_requests=10
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -331,20 +331,21 @@ Note that placeholders are formatted and replaced later on by Gracy based on the
 
 **Placeholders per event**
 
-| Placeholder        | Description                                           | Example                                     | Supported Events                   |
-| ------------------ | ----------------------------------------------------- | ------------------------------------------- | ---------------------------------- |
-| `{URL}`            | Full url being targetted                              | `https://pokeapi.co/api/v2/pokemon/pikachu` | *All*                              |
-| `{UURL}`           | Full **Unformatted** url being targetted              | `https://pokeapi.co/api/v2/pokemon/{NAME}`  | *All*                              |
-| `{ENDPOINT}`       | Endpoint being targetted                              | `/pokemon/pikachu`                          | *All*                              |
-| `{UENDPOINT}`      | **Unformatted** endpoint being targetted              | `/pokemon/{NAME}`                           | *All*                              |
-| `{METHOD}`         | HTTP Request being used                               | `GET`, `POST`                               | *All*                              |
-| `{STATUS}`         | Status code returned by the response                  | `200`, `404`, `501`                         | *After Request, On request errors* |
-| `{ELAPSED}`        | Amount of seconds taken for the request to complete   | *Numeric*                                   | *After Request, On request errors* |
-| `{RETRY_DELAY}`    | How long Gracy will wait before repeating the request | *Numeric*                                   | *Any Retry event*                  |
-| `{CUR_ATTEMPT}`    | Current attempt count for the current request         | *Numeric*                                   | *Any Retry event*                  |
-| `{MAX_ATTEMPT}`    | Max attempt defined for the current request           | *Numeric*                                   | *Any Retry event*                  |
-| `{THROTTLE_LIMIT}` | How many reqs/s is defined for the current request    | *Numeric*                                   | *Any Throttle event*               |
-| `{THROTTLE_TIME}`  | How long Gracy will wait before calling the request   | *Numeric*                                   | *Any Throttle event*               |
+| Placeholder             | Description                                           | Example                                     | Supported Events                   |
+| ----------------------- | ----------------------------------------------------- | ------------------------------------------- | ---------------------------------- |
+| `{URL}`                 | Full url being targetted                              | `https://pokeapi.co/api/v2/pokemon/pikachu` | *All*                              |
+| `{UURL}`                | Full **Unformatted** url being targetted              | `https://pokeapi.co/api/v2/pokemon/{NAME}`  | *All*                              |
+| `{ENDPOINT}`            | Endpoint being targetted                              | `/pokemon/pikachu`                          | *All*                              |
+| `{UENDPOINT}`           | **Unformatted** endpoint being targetted              | `/pokemon/{NAME}`                           | *All*                              |
+| `{METHOD}`              | HTTP Request being used                               | `GET`, `POST`                               | *All*                              |
+| `{STATUS}`              | Status code returned by the response                  | `200`, `404`, `501`                         | *After Request, On request errors* |
+| `{ELAPSED}`             | Amount of seconds taken for the request to complete   | *Numeric*                                   | *After Request, On request errors* |
+| `{RETRY_DELAY}`         | How long Gracy will wait before repeating the request | *Numeric*                                   | *Any Retry event*                  |
+| `{CUR_ATTEMPT}`         | Current attempt count for the current request         | *Numeric*                                   | *Any Retry event*                  |
+| `{MAX_ATTEMPT}`         | Max attempt defined for the current request           | *Numeric*                                   | *Any Retry event*                  |
+| `{THROTTLE_LIMIT}`      | How many reqs/s is defined for the current request    | *Numeric*                                   | *Any Throttle event*               |
+| `{THROTTLE_TIME}`       | How long Gracy will wait before calling the request   | *Numeric*                                   | *Any Throttle event*               |
+| `{THROTTLE_TIME_RANGE}` | Time range defined by the throttling rule             | `second`, `90 seconds`                      | *Any Throttle event*               |
 
 and you can set up the log events as follows:
 

--- a/README.md
+++ b/README.md
@@ -286,15 +286,20 @@ Gracy helps you proactively deal with it before any API throws 429 in your face.
 You can define rules per endpoint using regex:
 
 ```py
-TWO_REQS_FOR_ANY_ENDPOINT_RULE = ThrottleRule(
+SIMPLE_RULE = ThrottleRule(
   url_pattern=r".*",
   max_requests=2
 )
+print(SIMPLE_RULE)
+# Output: "2 requests per second for URLs matching re.compile('.*')"
 
-TEN_REQS_FOR_ANY_POKEMON_ENDPOINT_RULE = ThrottleRule(
+COMPLEX_RULE = ThrottleRule(
   url_pattern=r".*\/pokemon\/.*",
-  max_requests=10
+  max_requests=10,
+  per_time=timedelta(minutes=1, seconds=30),
 )
+print(COMPLEX_RULE)
+# Output: 10 requests per 90 seconds for URLs matching re.compile('.*\\/pokemon\\/.*')
 ```
 
 **Setting throttling**

--- a/examples/pokeapi_throttle.py
+++ b/examples/pokeapi_throttle.py
@@ -18,17 +18,15 @@ from gracy import (
 )
 
 RETRY = GracefulRetry(
-    delay=1,
+    delay=0,  # Force throttling to work
     max_attempts=3,
-    delay_modifier=1.5,
     retry_on=None,
-    log_before=LogEvent(LogLevel.WARNING),
     log_after=LogEvent(LogLevel.WARNING),
     log_exhausted=LogEvent(LogLevel.CRITICAL),
     behavior="pass",
 )
 
-THROTTLE_RULE = ThrottleRule(r".*", 3, timedelta(seconds=2))
+THROTTLE_RULE = ThrottleRule(r".*", 4, timedelta(seconds=2))
 
 
 class PokeApiEndpoint(BaseEndpoint):
@@ -41,9 +39,6 @@ class GracefulPokeAPI(Gracy[PokeApiEndpoint]):
         BASE_URL = "https://pokeapi.co/api/v2/"
         SETTINGS = GracyConfig(
             strict_status_code={HTTPStatus.OK},
-            log_errors=LogEvent(
-                LogLevel.ERROR, "How can I become a pokemon master if {URL} keeps failing with {STATUS}"
-            ),
             retry=RETRY,
             parser={
                 "default": lambda r: r.json(),
@@ -108,7 +103,7 @@ async def main():
         "lucario",
         "garchomp",
         "darkrai",
-        "giratina",
+        "giratina",  # (1) this fails, so good to test retry
         "arceus",
         "snivy",
         "tepig",
@@ -121,7 +116,7 @@ async def main():
         "froakie",
         "xerneas",
         "yveltal",
-        "zygarde",
+        "zygarde",  # (2) this fails, so good to test retry
         "decidueye",
         "incineroar",
     ]

--- a/examples/pokeapi_throttle.py
+++ b/examples/pokeapi_throttle.py
@@ -28,7 +28,7 @@ RETRY = GracefulRetry(
     behavior="pass",
 )
 
-ANY_URL_3_REQS_PER_2_SECS = ThrottleRule(r".*", 3, timedelta(seconds=2))
+THROTTLE_RULE = ThrottleRule(r".*", 3, timedelta(seconds=2))
 
 
 class PokeApiEndpoint(BaseEndpoint):
@@ -42,7 +42,7 @@ class GracefulPokeAPI(Gracy[PokeApiEndpoint]):
         SETTINGS = GracyConfig(
             strict_status_code={HTTPStatus.OK},
             log_errors=LogEvent(
-                LogLevel.ERROR, "How can I become a master pokemon if {URL} keeps failing with {STATUS}"
+                LogLevel.ERROR, "How can I become a pokemon master if {URL} keeps failing with {STATUS}"
             ),
             retry=RETRY,
             parser={
@@ -50,7 +50,7 @@ class GracefulPokeAPI(Gracy[PokeApiEndpoint]):
                 HTTPStatus.NOT_FOUND: None,
             },
             throttling=GracefulThrottle(
-                rules=ANY_URL_3_REQS_PER_2_SECS,
+                rules=THROTTLE_RULE,
                 log_limit_reached=LogEvent(LogLevel.ERROR),
                 log_wait_over=LogEvent(LogLevel.WARNING),
             ),
@@ -126,7 +126,7 @@ async def main():
         "incineroar",
     ]
     # pokemon_names = pokemon_names[:10]
-    print(f"Will query {len(pokemon_names)} pokemons concurrently - wish me luck")
+    print(f"Will query {len(pokemon_names)} pokemons concurrently - {str(THROTTLE_RULE)}")
 
     try:
         pokemon_reqs = [asyncio.create_task(pokeapi.get_pokemon(name)) for name in pokemon_names]

--- a/src/gracy/_core.py
+++ b/src/gracy/_core.py
@@ -60,26 +60,26 @@ async def _gracefully_throttle(controller: ThrottleController, request_context: 
                     await asyncio.sleep(await_time)
                     continue
 
-                if throttling.log_limit_reached:
-                    process_log_throttle(
-                        throttling.log_limit_reached,
-                        DefaultLogMessage.THROTTLE_HIT,
-                        await_time,
-                        rule,
-                        request_context,
-                    )
-
                 with THROTTLE_LOCKER.lock_rule(rule):
+                    if throttling.log_limit_reached:
+                        process_log_throttle(
+                            throttling.log_limit_reached,
+                            DefaultLogMessage.THROTTLE_HIT,
+                            await_time,
+                            rule,
+                            request_context,
+                        )
+
                     await asyncio.sleep(await_time)
 
-                if throttling.log_wait_over:
-                    process_log_throttle(
-                        throttling.log_wait_over,
-                        DefaultLogMessage.THROTTLE_DONE,
-                        await_time,
-                        rule,
-                        request_context,
-                    )
+                    if throttling.log_wait_over:
+                        process_log_throttle(
+                            throttling.log_wait_over,
+                            DefaultLogMessage.THROTTLE_DONE,
+                            await_time,
+                            rule,
+                            request_context,
+                        )
             else:
                 has_been_throttled = False
 

--- a/src/gracy/_loggers.py
+++ b/src/gracy/_loggers.py
@@ -19,7 +19,7 @@ class DefaultLogMessage(str, Enum):
     AFTER = "[{METHOD}] {URL} returned {STATUS}"
     ERRORS = "[{METHOD}] {URL} returned a bad status ({STATUS})"
 
-    THROTTLE_HIT = "{URL} hit {THROTTLE_LIMIT} reqs/s"
+    THROTTLE_HIT = "{URL} hit {THROTTLE_LIMIT} reqs/{THROTTLE_TIME_RANGE}"
     THROTTLE_DONE = "Done waiting {THROTTLE_TIME}s to hit {URL}"
 
     RETRY_BEFORE = (
@@ -67,7 +67,8 @@ def process_log_throttle(
     format_args = dict(
         **_extract_base_format_args(request_context),
         THROTTLE_TIME=await_time,
-        THROTTLE_LIMIT=rule.requests_per_second_limit,
+        THROTTLE_LIMIT=rule.max_requests,
+        THROTTLE_TIME_RANGE=rule.readable_time_range,
     )
 
     _do_log(logevent, default_message, format_args)

--- a/src/gracy/_models.py
+++ b/src/gracy/_models.py
@@ -145,8 +145,8 @@ class ThrottleRule:
     Used in combination with `max_requests` to measure throttle
     """
 
-    def __init__(self, url_regex: str, max_requests: int, per_time: timedelta = timedelta(seconds=1)) -> None:
-        self.url_pattern = re.compile(url_regex)
+    def __init__(self, url_pattern: str, max_requests: int, per_time: timedelta = timedelta(seconds=1)) -> None:
+        self.url_pattern = re.compile(url_pattern)
         self.max_requests = max_requests
         self.per_time_range = per_time
 

--- a/src/gracy/_models.py
+++ b/src/gracy/_models.py
@@ -180,7 +180,7 @@ class ThrottleRule:
             return ", ".join(parts[:-1]) + " and " + parts[-1]
 
     def __str__(self) -> str:
-        return f"{self.max_requests} per {self.readable_time_range} for URLs matching {self.url_pattern}"
+        return f"{self.max_requests} requests per {self.readable_time_range} for URLs matching {self.url_pattern}"
 
     def calculate_await_time(self, controller: ThrottleController) -> float:
         """

--- a/src/gracy/_models.py
+++ b/src/gracy/_models.py
@@ -7,11 +7,10 @@ import re
 from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum, IntEnum
 from http import HTTPStatus
 from threading import Lock
-from time import time
 from typing import Any, Awaitable, Callable, Final, Iterable, Literal, Pattern, TypeVar
 
 import httpx
@@ -136,25 +135,35 @@ class ThrottleRule:
         - `"http(s)?://myapi.com/.*"`
     """
 
-    requests_per_second_limit: float
+    max_requests: float
     """
-    How many requests should be run per second
+    How many requests should be run `per_time_range`
     """
 
-    def __init__(self, url_regex: str, limit_per_second: int) -> None:
+    per_time_range: timedelta
+    """
+    Used in combination with `max_requests` to measure throttle
+    """
+
+    def __init__(self, url_regex: str, max_requests: int, per_time: timedelta = timedelta(seconds=1)) -> None:
         self.url_pattern = re.compile(url_regex)
-        self.requests_per_second_limit = limit_per_second
+        self.max_requests = max_requests
+        self.per_time_range = per_time
+
+    @property
+    def readable_time_range(self) -> str:
+        return ""  # TODO
 
     def calculate_await_time(self, controller: ThrottleController) -> float:
         """
         Checks current reqs/second and awaits if limit is reached.
         Returns whether limit was hit or not.
         """
-        rate_limit = self.requests_per_second_limit
-        cur_reqs_second = controller.calculate_requests_per_second(self.url_pattern)
+        rate_limit = self.max_requests
+        cur_rate = controller.calculate_requests_per_rule(self.url_pattern, self.per_time_range)
 
-        if cur_reqs_second >= rate_limit:
-            time_diff = (rate_limit - cur_reqs_second) or 1
+        if cur_rate >= rate_limit:
+            time_diff = (rate_limit - cur_rate) or 1
             waiting_time = 1.0 / time_diff
             return waiting_time
 
@@ -201,27 +210,40 @@ class GracefulThrottle:
 
 class ThrottleController:
     def __init__(self) -> None:
-        self._control: dict[str, list[float]] = defaultdict[str, list[float]](list)
+        self._control: dict[str, list[datetime]] = defaultdict[str, list[datetime]](list)
 
     def init_request(self, request_context: GracyRequestContext):
         with THROTTLE_LOCKER.lock_check():
-            self._control[request_context.url].append(time())  # This should always keep it sorted asc
+            self._control[request_context.url].append(datetime.now())  # This should always keep it sorted asc
 
-    def calculate_requests_per_second(self, url_pattern: Pattern[str]) -> float:
+    def calculate_requests_per_rule(self, url_pattern: Pattern[str], range: timedelta) -> float:
         with THROTTLE_LOCKER.lock_check():
-            up_to_one_sec = time() - 1
-            requests_per_second = 0.0
-            coalesced_started_ats = sorted(
-                itertools.chain(*[started_ats for url, started_ats in self._control.items() if url_pattern.match(url)])
+            past_time_window = datetime.now() - range
+            request_rate = 0.0
+
+            request_times = sorted(
+                itertools.chain(
+                    *[started_ats for url, started_ats in self._control.items() if url_pattern.match(url)],
+                ),
+                reverse=True,
             )
 
-            if coalesced_started_ats:
-                requests = [request for request in coalesced_started_ats if request >= up_to_one_sec]
-                requests_per_second = len(requests) / 1
+            req_idx = 0
+            total_reqs = len(request_times)
+            while req_idx < total_reqs:
+                # e.g. Limit 4 requests per 2 seconds, now is 09:55
+                # request_time=09:54 >= past_time_window=09:53
+                if request_times[req_idx] >= past_time_window:
+                    request_rate += 1
+                else:
+                    # Because it's sorted desc there's no need to keep iterating
+                    return request_rate
 
-            return requests_per_second
+                req_idx += 1
 
-    def calculate_requests_rate(self, url_pattern: Pattern[str]) -> float:
+            return request_rate
+
+    def calculate_requests_per_sec(self, url_pattern: Pattern[str]) -> float:
         with THROTTLE_LOCKER.lock_check():
             requests_per_second = 0.0
             coalesced_started_ats = sorted(
@@ -230,12 +252,12 @@ class ThrottleController:
 
             if coalesced_started_ats:
                 # Best effort to measure rate if we just performed 1 request
-                last = coalesced_started_ats[-1] if len(coalesced_started_ats) > 1 else time()
+                last = coalesced_started_ats[-1] if len(coalesced_started_ats) > 1 else datetime.now()
                 start = coalesced_started_ats[0]
                 elapsed = last - start
 
-                if elapsed > 0:
-                    requests_per_second = len(coalesced_started_ats) / elapsed
+                if elapsed.seconds > 0:
+                    requests_per_second = len(coalesced_started_ats) / elapsed.seconds
 
             return requests_per_second
 
@@ -251,7 +273,7 @@ class ThrottleController:
         table.add_column("Times", justify="right")
 
         for url, times in self._control.items():
-            human_times = [datetime.fromtimestamp(ts).strftime("%H:%M:%S.%f") for ts in times]
+            human_times = [time.strftime("%H:%M:%S.%f") for time in times]
             table.add_row(url, f"{len(times):,}", str(human_times))
 
         console.print(table)

--- a/src/gracy/_models.py
+++ b/src/gracy/_models.py
@@ -135,7 +135,7 @@ class ThrottleRule:
         - `"http(s)?://myapi.com/.*"`
     """
 
-    max_requests: float
+    max_requests: int
     """
     How many requests should be run `per_time_range`
     """
@@ -149,6 +149,9 @@ class ThrottleRule:
         self.url_pattern = re.compile(url_regex)
         self.max_requests = max_requests
         self.per_time_range = per_time
+
+        if isinstance(max_requests, float):
+            raise TypeError(f"{max_requests=} should be an integer")
 
     @property
     def readable_time_range(self) -> str:

--- a/src/gracy/_models.py
+++ b/src/gracy/_models.py
@@ -192,7 +192,7 @@ class ThrottleRule:
 
         if cur_rate >= rate_limit:
             time_diff = (rate_limit - cur_rate) or 1
-            waiting_time = 1.0 / time_diff
+            waiting_time = self.per_time_range.total_seconds() / time_diff
             return waiting_time
 
         return 0.0

--- a/src/gracy/_reports/_builders.py
+++ b/src/gracy/_reports/_builders.py
@@ -25,7 +25,7 @@ class ReportBuilder:
 
     def _calculate_req_rate_for_url(self, unformatted_url: str, throttle_controller: ThrottleController) -> float:
         pattern = re.compile(re.sub(r"{(\w+)}", ANY_REGEX, unformatted_url))
-        rate = throttle_controller.calculate_requests_rate(pattern)
+        rate = throttle_controller.calculate_requests_per_sec(pattern)
         return rate
 
     def build(self, throttle_controller: ThrottleController, replay_settings: GracyReplay | None) -> GracyReport:


### PR DESCRIPTION
## What changed

Enhanced throttle rule to accept any arbitrary `timedelta` which allows users to define it like:

```py
THROTTLE_RULE = ThrottleRule(r".*", 4, timedelta(minutes=1, seconds=1))
```

This would translate to 4 reqs per 61 seconds.

Resolves #5 

### Tests

I enhanced `pokeapi_throttling.py` test with the following conditions:

- Query 50 different pokemons
- Set throttling to 4 requests per 2 seconds for any URL
- 2 Pokemons have invalid names for the poke-api (which triggers the retry logic)
- Adjusted retry wait to 0 (To force throttling to do the work)


```
❯ /home/guilatrova/guilatrova/gracy/.venv/bin/python /home/guilatrova/guilatrova/gracy/examples/pokeapi_throttle.py
Will query 50 pokemons concurrently - 4 requests per 2 seconds for URLs matching re.compile('.*')
2023-02-17 06:18:07,545 https://pokeapi.co/api/v2/pokemon/jigglypuff hit 4 reqs/2 seconds
pikachu is #35 in the pokedex
squirtle is #10 in the pokedex
bulbasaur is #1 in the pokedex
charmander is #5 in the pokedex
2023-02-17 06:18:09,548 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/jigglypuff
2023-02-17 06:18:09,549 https://pokeapi.co/api/v2/pokemon/mew hit 4 reqs/2 seconds
mewtwo is #245 in the pokedex
jigglypuff is #71 in the pokedex
gyarados is #211 in the pokedex
dragonite is #244 in the pokedex
2023-02-17 06:18:11,552 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/mew
2023-02-17 06:18:11,553 https://pokeapi.co/api/v2/pokemon/pichu hit 4 reqs/2 seconds
mew is #248 in the pokedex
cyndaquil is #252 in the pokedex
chikorita is #249 in the pokedex
totodile is #255 in the pokedex
2023-02-17 06:18:13,556 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/pichu
2023-02-17 06:18:13,557 https://pokeapi.co/api/v2/pokemon/feraligatr hit 4 reqs/2 seconds
togepi is #268 in the pokedex
pichu is #34 in the pokedex
ampharos is #275 in the pokedex
typhlosion is #254 in the pokedex
2023-02-17 06:18:15,560 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/feraligatr
2023-02-17 06:18:15,560 https://pokeapi.co/api/v2/pokemon/ho-oh hit 4 reqs/2 seconds
feraligatr is #257 in the pokedex
espeon is #220 in the pokedex
umbreon is #221 in the pokedex
lugia is #344 in the pokedex
2023-02-17 06:18:17,563 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/ho-oh
2023-02-17 06:18:17,564 https://pokeapi.co/api/v2/pokemon/gardevoir hit 4 reqs/2 seconds
ho-oh is #345 in the pokedex
treecko is #347 in the pokedex
torchic is #351 in the pokedex
mudkip is #355 in the pokedex
2023-02-17 06:18:19,567 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/gardevoir
2023-02-17 06:18:19,567 https://pokeapi.co/api/v2/pokemon/rayquaza hit 4 reqs/2 seconds
sceptile is #349 in the pokedex
gardevoir is #382 in the pokedex
blaziken is #353 in the pokedex
swampert is #357 in the pokedex
2023-02-17 06:18:21,570 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/rayquaza
2023-02-17 06:18:21,571 https://pokeapi.co/api/v2/pokemon/garchomp hit 4 reqs/2 seconds
rayquaza is #511 in the pokedex
latias is #503 in the pokedex
latios is #505 in the pokedex
lucario is #573 in the pokedex
2023-02-17 06:18:23,572 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/garchomp
2023-02-17 06:18:23,573 https://pokeapi.co/api/v2/pokemon/snivy hit 4 reqs/2 seconds
garchomp is #570 in the pokedex
arceus is #608 in the pokedex
darkrai is #605 in the pokedex
2023-02-17 06:18:25,576 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/snivy
2023-02-17 06:18:25,577 https://pokeapi.co/api/v2/pokemon/reshiram hit 4 reqs/2 seconds
tepig is #613 in the pokedex
zekrom is #769 in the pokedex
snivy is #610 in the pokedex
oshawott is #616 in the pokedex
2023-02-17 06:18:27,579 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/reshiram
2023-02-17 06:18:27,580 https://pokeapi.co/api/v2/pokemon/froakie hit 4 reqs/2 seconds
reshiram is #768 in the pokedex
fennekin is #783 in the pokedex
victini is #609 in the pokedex
chespin is #780 in the pokedex
2023-02-17 06:18:29,583 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/froakie
2023-02-17 06:18:29,584 https://pokeapi.co/api/v2/pokemon/decidueye hit 4 reqs/2 seconds
xerneas is #856 in the pokedex
froakie is #786 in the pokedex
yveltal is #857 in the pokedex
2023-02-17 06:18:31,587 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/decidueye
2023-02-17 06:18:31,588 https://pokeapi.co/api/v2/generation/3 hit 4 reqs/2 seconds
decidueye is #870 in the pokedex
incineroar is #873 in the pokedex
2023-02-17 06:18:33,590 Done waiting 2.0s to hit https://pokeapi.co/api/v2/generation/3
2023-02-17 06:18:33,644 GracefulRetry: https://pokeapi.co/api/v2/pokemon/giratina attempt (2 out of 3)
2023-02-17 06:18:33,648 GracefulRetry: https://pokeapi.co/api/v2/pokemon/zygarde attempt (2 out of 3)
2023-02-17 06:18:33,648 https://pokeapi.co/api/v2/pokemon/zygarde hit 4 reqs/2 seconds
2023-02-17 06:18:33,677 GracefulRetry: https://pokeapi.co/api/v2/pokemon/giratina attempt (3 out of 3)
2023-02-17 06:18:33,677 GracefulRetry: https://pokeapi.co/api/v2/pokemon/giratina exhausted the maximum attempts of 3
2023-02-17 06:18:35,651 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/zygarde
2023-02-17 06:18:35,680 GracefulRetry: https://pokeapi.co/api/v2/pokemon/zygarde attempt (3 out of 3)
2023-02-17 06:18:35,680 GracefulRetry: https://pokeapi.co/api/v2/pokemon/zygarde exhausted the maximum attempts of 3
2023-02-17 06:18:35,705 GracefulRetry: https://pokeapi.co/api/v2/pokemon/giratina attempt (2 out of 3)
2023-02-17 06:18:35,712 GracefulRetry: https://pokeapi.co/api/v2/pokemon/zygarde attempt (2 out of 3)
2023-02-17 06:18:35,712 https://pokeapi.co/api/v2/pokemon/zygarde hit 4 reqs/2 seconds
2023-02-17 06:18:35,736 GracefulRetry: https://pokeapi.co/api/v2/pokemon/giratina attempt (3 out of 3)
2023-02-17 06:18:35,736 GracefulRetry: https://pokeapi.co/api/v2/pokemon/giratina exhausted the maximum attempts of 3
giratina was not found
2023-02-17 06:18:37,715 Done waiting 2.0s to hit https://pokeapi.co/api/v2/pokemon/zygarde
2023-02-17 06:18:37,748 GracefulRetry: https://pokeapi.co/api/v2/pokemon/zygarde attempt (3 out of 3)
2023-02-17 06:18:37,748 GracefulRetry: https://pokeapi.co/api/v2/pokemon/zygarde exhausted the maximum attempts of 3
zygarde was not found
                                                                                  Gracy Requests Summary                                                                                  
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃ URL                                       ┃ Total Reqs (#) ┃ Success (%) ┃ Fail (%) ┃ Avg Latency (s) ┃ Max Latency (s) ┃ 2xx Resps ┃ 3xx Resps ┃ 4xx Resps ┃ 5xx Resps ┃ Avg Reqs/sec ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ https://pokeapi.co/api/v2/pokemon/{NAME}  │             58 │      82.76% │   17.24% │            0.04 │            0.11 │        48 │         0 │        10 │         0 │   1.9 reqs/s │
│ https://pokeapi.co/api/v2/generation/{ID} │              3 │     100.00% │    0.00% │            0.03 │            0.03 │         3 │         0 │         0 │         0 │   1.5 reqs/s │
├───────────────────────────────────────────┼────────────────┼─────────────┼──────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────┼───────────┼──────────────┤
│ TOTAL                                     │             61 │      83.61% │   16.39% │            0.03 │            0.00 │        51 │         0 │        10 │         0 │   1.7 reqs/s │
└───────────────────────────────────────────┴────────────────┴─────────────┴──────────┴─────────────────┴─────────────────┴───────────┴───────────┴───────────┴───────────┴──────────────┘
                                                                    Throttling Summary                                                                    
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ URL                                          ┃ Count ┃                                                                                           Times ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ https://pokeapi.co/api/v2/pokemon/bulbasaur  │     1 │                                                                             ['06:18:07.532502'] │
│ https://pokeapi.co/api/v2/pokemon/charmander │     1 │                                                                             ['06:18:07.545109'] │
│ https://pokeapi.co/api/v2/pokemon/squirtle   │     1 │                                                                             ['06:18:07.545373'] │
│ https://pokeapi.co/api/v2/pokemon/pikachu    │     1 │                                                                             ['06:18:07.545537'] │
│ https://pokeapi.co/api/v2/pokemon/jigglypuff │     1 │                                                                             ['06:18:09.548477'] │
│ https://pokeapi.co/api/v2/pokemon/mewtwo     │     1 │                                                                             ['06:18:09.548770'] │
│ https://pokeapi.co/api/v2/pokemon/gyarados   │     1 │                                                                             ['06:18:09.548917'] │
│ https://pokeapi.co/api/v2/pokemon/dragonite  │     1 │                                                                             ['06:18:09.549059'] │
│ https://pokeapi.co/api/v2/pokemon/mew        │     1 │                                                                             ['06:18:11.552437'] │
│ https://pokeapi.co/api/v2/pokemon/chikorita  │     1 │                                                                             ['06:18:11.552697'] │
│ https://pokeapi.co/api/v2/pokemon/cyndaquil  │     1 │                                                                             ['06:18:11.552829'] │
│ https://pokeapi.co/api/v2/pokemon/totodile   │     1 │                                                                             ['06:18:11.552943'] │
│ https://pokeapi.co/api/v2/pokemon/pichu      │     1 │                                                                             ['06:18:13.556412'] │
│ https://pokeapi.co/api/v2/pokemon/togepi     │     1 │                                                                             ['06:18:13.556682'] │
│ https://pokeapi.co/api/v2/pokemon/ampharos   │     1 │                                                                             ['06:18:13.556827'] │
│ https://pokeapi.co/api/v2/pokemon/typhlosion │     1 │                                                                             ['06:18:13.556943'] │
│ https://pokeapi.co/api/v2/pokemon/feraligatr │     1 │                                                                             ['06:18:15.560264'] │
│ https://pokeapi.co/api/v2/pokemon/espeon     │     1 │                                                                             ['06:18:15.560537'] │
│ https://pokeapi.co/api/v2/pokemon/umbreon    │     1 │                                                                             ['06:18:15.560680'] │
│ https://pokeapi.co/api/v2/pokemon/lugia      │     1 │                                                                             ['06:18:15.560797'] │
│ https://pokeapi.co/api/v2/pokemon/ho-oh      │     1 │                                                                             ['06:18:17.563767'] │
│ https://pokeapi.co/api/v2/pokemon/treecko    │     1 │                                                                             ['06:18:17.564058'] │
│ https://pokeapi.co/api/v2/pokemon/torchic    │     1 │                                                                             ['06:18:17.564239'] │
│ https://pokeapi.co/api/v2/pokemon/mudkip     │     1 │                                                                             ['06:18:17.564365'] │
│ https://pokeapi.co/api/v2/pokemon/gardevoir  │     1 │                                                                             ['06:18:19.567135'] │
│ https://pokeapi.co/api/v2/pokemon/sceptile   │     1 │                                                                             ['06:18:19.567425'] │
│ https://pokeapi.co/api/v2/pokemon/blaziken   │     1 │                                                                             ['06:18:19.567560'] │
│ https://pokeapi.co/api/v2/pokemon/swampert   │     1 │                                                                             ['06:18:19.567670'] │
│ https://pokeapi.co/api/v2/pokemon/rayquaza   │     1 │                                                                             ['06:18:21.570965'] │
│ https://pokeapi.co/api/v2/pokemon/latias     │     1 │                                                                             ['06:18:21.571242'] │
│ https://pokeapi.co/api/v2/pokemon/latios     │     1 │                                                                             ['06:18:21.571386'] │
│ https://pokeapi.co/api/v2/pokemon/lucario    │     1 │                                                                             ['06:18:21.571504'] │
│ https://pokeapi.co/api/v2/pokemon/garchomp   │     1 │                                                                             ['06:18:23.572571'] │
│ https://pokeapi.co/api/v2/pokemon/darkrai    │     1 │                                                                             ['06:18:23.572843'] │
│ https://pokeapi.co/api/v2/pokemon/giratina   │     5 │ ['06:18:23.572996', '06:18:33.616554', '06:18:33.644688', '06:18:35.677760', '06:18:35.705423'] │
│ https://pokeapi.co/api/v2/pokemon/arceus     │     1 │                                                                             ['06:18:23.573145'] │
│ https://pokeapi.co/api/v2/pokemon/snivy      │     1 │                                                                             ['06:18:25.576335'] │
│ https://pokeapi.co/api/v2/pokemon/tepig      │     1 │                                                                             ['06:18:25.576613'] │
│ https://pokeapi.co/api/v2/pokemon/oshawott   │     1 │                                                                             ['06:18:25.576786'] │
│ https://pokeapi.co/api/v2/pokemon/zekrom     │     1 │                                                                             ['06:18:25.576910'] │
│ https://pokeapi.co/api/v2/pokemon/reshiram   │     1 │                                                                             ['06:18:27.579844'] │
│ https://pokeapi.co/api/v2/pokemon/victini    │     1 │                                                                             ['06:18:27.580120'] │
│ https://pokeapi.co/api/v2/pokemon/chespin    │     1 │                                                                             ['06:18:27.580284'] │
│ https://pokeapi.co/api/v2/pokemon/fennekin   │     1 │                                                                             ['06:18:27.580406'] │
│ https://pokeapi.co/api/v2/pokemon/froakie    │     1 │                                                                             ['06:18:29.583743'] │
│ https://pokeapi.co/api/v2/pokemon/xerneas    │     1 │                                                                             ['06:18:29.584014'] │
│ https://pokeapi.co/api/v2/pokemon/yveltal    │     1 │                                                                             ['06:18:29.584174'] │
│ https://pokeapi.co/api/v2/pokemon/zygarde    │     5 │ ['06:18:29.584320', '06:18:33.620003', '06:18:35.651652', '06:18:35.680546', '06:18:37.715382'] │
│ https://pokeapi.co/api/v2/pokemon/decidueye  │     1 │                                                                             ['06:18:31.587368'] │
│ https://pokeapi.co/api/v2/pokemon/incineroar │     1 │                                                                             ['06:18:31.587678'] │
│ https://pokeapi.co/api/v2/generation/1       │     1 │                                                                             ['06:18:31.587849'] │
│ https://pokeapi.co/api/v2/generation/2       │     1 │                                                                             ['06:18:31.587972'] │
│ https://pokeapi.co/api/v2/generation/3       │     1 │                                                                             ['06:18:33.590680'] │
└──────────────────────────────────────────────┴───────┴─────────────────────────────────────────────────────────────────────────────────────────────────┘
```