### PR TITLE
ci: use proper job for poetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install poetry
+        shell: bash
+        run: pipx install poetry
+
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
         os: [ubuntu-latest] #, macOS-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
@@ -31,25 +31,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install poetry
-        uses: Gr1N/setup-poetry@v7
-
-      - name: Cache poetry dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+          cache: poetry
+          # key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          poetry config virtualenvs.create false
-          poetry install
+        run: poetry install
 
       - name: Lint
         uses: pre-commit/action@v2.0.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GRACY_GITHUB_TOKEN }}
 
+      - name: Install poetry
+        shell: bash
+        run: pipx install poetry
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,21 +20,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-
-      - name: Install poetry
-        uses: Gr1N/setup-poetry@v7
-
-      - name: Cache poetry dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          poetry config virtualenvs.create false
-          poetry install
+          cache: poetry
 
       - name: Python Semantic Release
         run: |

--- a/src/gracy/replays/storages/pymongo.py
+++ b/src/gracy/replays/storages/pymongo.py
@@ -94,7 +94,8 @@ class MongoReplayStorage(GracyReplayStorage):
         response_serialized = pickle.dumps(response)
 
         response_content = response.text or None
-        if "json" in response.headers.get("Content-Type"):
+        content_type = response.headers.get("Content-Type")
+        if content_type and "json" in content_type:
             try:
                 jsonified_content = response.json()
 

--- a/src/tests/test_hooks.py
+++ b/src/tests/test_hooks.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import httpx
 
 from gracy import GracefulRetry, GracefulRetryState, Gracy, GracyConfig, GracyRequestContext
+from gracy.exceptions import GracyRequestFailed
 from tests.conftest import MISSING_NAME, PRESENT_NAME, REPLAY, PokeApiEndpoint, assert_requests_made
 
 RETRY: t.Final = GracefulRetry(
@@ -123,7 +124,7 @@ async def test_after_hook_counts_aborts():
     with patch.object(pokeapi, "_client", autospec=True) as mock:
         mock.request.side_effect = SomeRequestException("Request failed")
 
-        with pytest.raises(SomeRequestException):
+        with pytest.raises(GracyRequestFailed):
             await pokeapi.get_pokemon(PRESENT_NAME)
 
     assert pokeapi.after_status_counter[HTTPStatus.OK] == 0


### PR DESCRIPTION
- Update CI jobs to install poetry/packages
- Fix replays by @logan-silk  (Closes #20)
- Create a proper exception for failed requests: `GracyRequestFailed`, so we can retry properly