### PR TITLE
feat(monitor): client-emitted messages via api.message() + scrollable panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,56 @@ Zero overhead when off (nothing is imported), and a broken snapshot can never ta
 
 Want to see it shine without writing code? Run [examples/v2_monitor_demo.py](./examples/v2_monitor_demo.py) in one terminal and `python -m gracy.monitor` in another; it spins a local misbehaving API and fires bursty traffic that lights up every tile.
 
+#### 💬 Messages: your code talks on the dashboard
+
+The tiles show what Gracy *infers*; `message()` lets your code mark business context on the same timeline - no separate logger fighting the TUI for the terminal:
+
+```py
+api.message("base resources fetched")                  # plain progress marker
+api.message("rate limit near ceiling", level="warn")   # info | warn | error
+```
+
+Messages appear in a dedicated panel (hidden until the first one arrives, then growing one line per message up to 3) that always follows the latest 3. Nothing is lost: the viewer keeps up to 1,000 messages - scroll the history with **↑/↓**, **PgUp/PgDn**, **Home** (vi `j`/`k` work too); **End**/**Esc** snaps back to the live tail. Like everything monitor-related it's fire-and-forget: never raises, works before `build()` and after `aclose()`, and is a no-op cost when monitoring is off.
+
+```
+╭─ messages · 12 ──────────────────────────────────────────────────────────╮
+│ 14:03:41 • base resources fetched                                        │
+│ 14:03:52 • rate limit near ceiling                                       │
+│ 14:03:58 • starting phase 2                                              │
+╰─────────────────────────────────────────────────────────────── ↑ older ─╯
+```
+
+**Live gauges with `key=`.** Pass a `key` and each call *replaces* the previous message with the same key instead of appending - one panel line, updated in place, that never floods the history. That's the tool for aggregates recomputed on every request, typically from an [after-hook](#hooks). The classic: track how much an LLM session is costing you, straight from real `usage` payloads:
+
+```py
+class OpenAIChat(Gracy):
+    base_url = "https://api.openai.com"
+    prompt_tokens = completion_tokens = 0
+
+    @post("/v1/chat/completions")
+    async def chat(self, payload: Annotated[dict, Body]) -> dict: ...
+
+    async def after(self, context, result, retry_state) -> None:
+        if not (isinstance(result, gracy.Response) and result.is_success):
+            return
+        usage = result.json().get("usage") or {}
+        cls = type(self)
+        cls.prompt_tokens += usage.get("prompt_tokens", 0)
+        cls.completion_tokens += usage.get("completion_tokens", 0)
+        cost = (cls.prompt_tokens * 2.50 + cls.completion_tokens * 10.00) / 1_000_000
+        self.message(
+            f"openai: {cls.prompt_tokens:,} in / {cls.completion_tokens:,} out tok · est. ${cost:.4f}",
+            level="warn" if cost >= 0.05 else "info",
+            key="openai-cost",  # <- one line, updated in place
+        )
+```
+
+```
+│ 14:07:12 • openai: 10,752 in / 6,816 out tok · est. $0.0950              │
+```
+
+Try it without spending a cent: [examples/v2_openai_cost_demo.py](./examples/v2_openai_cost_demo.py) mocks the OpenAI API with real-shape `chat.completion` payloads and drives the cost gauge live (the wave-by-wave `message()` flow is in [examples/v2_monitor_demo.py](./examples/v2_monitor_demo.py)).
+
 ### 📚 Generate docs from your client
 
 Your class **is** the spec. Every path, param kind, return type, `on=` status action, retry/throttle policy, and docstring is already declared on your Gracy client, so gracy can generate API documentation from it, statically. No instance is created, nothing is started, no network is touched: it works from the class alone.

--- a/examples/v2_monitor_demo.py
+++ b/examples/v2_monitor_demo.py
@@ -144,7 +144,8 @@ BANNER = """
 
   Watch for: IN-FLIGHT (capped at 4), ON HOLD (burst backlog), THROTTLES
   (8 req/s ceiling), PAUSED (429 + Retry-After freezes the client),
-  RETRIES (flaky 503s) and ABORTS (retries exhausted).
+  RETRIES (flaky 503s), ABORTS (retries exhausted) and the MESSAGES panel
+  (one api.message() per wave - scroll the history with the arrow keys).
 
   Ctrl+C stops the demo cleanly.
 =========================================================================
@@ -160,6 +161,7 @@ async def main() -> None:
     api = DemoAPI(monitor=True)
     try:
         await api.build()
+        api.message(f"demo API up at {base_url}, hammering it for {RUN_FOR_S:.0f}s")
         deadline = time.monotonic() + RUN_FOR_S
         wave = 0
         while time.monotonic() < deadline:
@@ -167,7 +169,12 @@ async def main() -> None:
             results = await asyncio.gather(*_mixed_wave(api), return_exceptions=True)
             failed = sum(1 for r in results if isinstance(r, BaseException))
             print(f"wave {wave:>2}: {len(results) - failed:>2} ok / {failed} aborted", flush=True)
+            api.message(
+                f"wave {wave} done: {len(results) - failed} ok / {failed} aborted",
+                level="warn" if failed else "info",
+            )
             await asyncio.sleep(LULL_S)  # short lull so the sparklines breathe
+        api.message("demo finished - source will grey out and be reaped")
         print("demo finished - the dashboard greys this source out, then reaps it")
     except KeyboardInterrupt:
         print("\ninterrupted - shutting down cleanly")

--- a/examples/v2_monitor_demo.py
+++ b/examples/v2_monitor_demo.py
@@ -94,6 +94,15 @@ def start_server() -> tuple[ThreadingHTTPServer, str]:
 
 class DemoAPI(Gracy):
     # base_url is stamped in main() once the local server picks its port.
+    payload_bytes = 0  # aggregated by the after-hook below (one instance per demo run)
+
+    async def after(self, context: t.Any, result: t.Any, retry_state: t.Any) -> None:
+        """Sum every response payload and surface the total as a live gauge:
+        the key makes each call REPLACE the previous line instead of appending."""
+        if isinstance(result, gracy.Response):
+            type(self).payload_bytes += len(result.body)
+            self.message(f"payload so far: {type(self).payload_bytes / 1024:,.1f} KiB", key="payload")
+
     config = GracyConfig(
         retry=Retry(on=gracy.status(503, 429), attempts=3, wait=0.3),
         throttle=Throttle(rules=[Rate(8, per="1s")]),
@@ -144,8 +153,9 @@ BANNER = """
 
   Watch for: IN-FLIGHT (capped at 4), ON HOLD (burst backlog), THROTTLES
   (8 req/s ceiling), PAUSED (429 + Retry-After freezes the client),
-  RETRIES (flaky 503s), ABORTS (retries exhausted) and the MESSAGES panel
-  (one api.message() per wave - scroll the history with the arrow keys).
+  RETRIES (flaky 503s), ABORTS (retries exhausted) and the MESSAGES panel:
+  one api.message() per wave (scroll the history with the arrow keys) plus
+  a live payload-size gauge aggregated by an after-hook (keyed message).
 
   Ctrl+C stops the demo cleanly.
 =========================================================================

--- a/examples/v2_openai_cost_demo.py
+++ b/examples/v2_openai_cost_demo.py
@@ -1,0 +1,150 @@
+"""Gracy 2.0 live cost gauge demo - OpenAI chat completions, ZERO credits spent.
+
+Terminal A:  python examples/v2_openai_cost_demo.py
+Terminal B:  python -m gracy.monitor
+
+A MockTransport answers every request with a real-shape ``chat.completion``
+payload (the exact JSON the OpenAI API returns, ``usage`` block included), so
+no API key is needed and no credits are spent. An after-hook reads ``usage``
+from each response, aggregates prompt vs completion tokens across the whole
+session, prices them (arbitrary demo rates - swap in your model's real ones)
+and publishes a SINGLE live gauge line on the monitor via a keyed message:
+
+    14:03:52 • openai: 1,234 in / 567 out tok · est. $0.0123
+
+Because the message uses ``key="openai-cost"``, every update REPLACES the
+previous line instead of appending - the history never fills up with
+intermediate totals, and the gauge escalates to warn/error as spend grows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+import typing as t
+
+import gracy
+from gracy import Body, Gracy, post
+from gracy.testing import MockTransport
+
+RUN_FOR_S = 45.0
+
+# Arbitrary demo pricing (USD per 1M tokens) - the user brings real rates.
+PRICE_IN_PER_1M = 2.50
+PRICE_OUT_PER_1M = 10.00
+WARN_AT_USD = 0.05  # gauge turns yellow here...
+ERROR_AT_USD = 0.12  # ...and red here
+
+
+def fake_completion(spec: t.Any) -> dict[str, t.Any]:
+    """Real-shape OpenAI chat.completion response with wandering usage numbers
+    so the gauge visibly climbs."""
+    prompt = random.randint(200, 1200)
+    completion = random.randint(50, 800)
+    return {
+        "id": f"chatcmpl-demo{random.randint(10**8, 10**9 - 1)}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Mocked answer - no credits were harmed.",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+            "total_tokens": prompt + completion,
+        },
+    }
+
+
+class OpenAIChat(Gracy):
+    base_url = "https://api.openai.com"
+
+    # Session-wide aggregates, owned by the after-hook (one instance per run).
+    prompt_tokens = 0
+    completion_tokens = 0
+
+    @post("/v1/chat/completions")
+    async def chat(self, payload: t.Annotated[dict, Body]) -> dict: ...
+
+    async def after(self, context: t.Any, result: t.Any, retry_state: t.Any) -> None:
+        """Aggregate token usage from every successful response and surface the
+        running cost as one keyed gauge on the live monitor."""
+        if not (isinstance(result, gracy.Response) and result.is_success):
+            return
+        usage = result.json().get("usage") or {}
+        cls = type(self)
+        cls.prompt_tokens += int(usage.get("prompt_tokens", 0))
+        cls.completion_tokens += int(usage.get("completion_tokens", 0))
+        cost = (
+            cls.prompt_tokens * PRICE_IN_PER_1M + cls.completion_tokens * PRICE_OUT_PER_1M
+        ) / 1_000_000
+        level = "error" if cost >= ERROR_AT_USD else ("warn" if cost >= WARN_AT_USD else "info")
+        self.message(
+            f"openai: {cls.prompt_tokens:,} in / {cls.completion_tokens:,} out tok"
+            f" · est. ${cost:.4f}",
+            level=level,
+            key="openai-cost",
+        )
+
+
+BANNER = """
+=========================================================================
+  GRACY OPENAI COST GAUGE DEMO (mocked - zero credits, no API key)
+
+  >>> Open a SECOND terminal and run:
+
+      python -m gracy.monitor
+
+  Watch the MESSAGES panel: the "openai: ... est. $" line is ONE keyed
+  gauge updated in place by an after-hook, turning yellow past ${warn}
+  and red past ${error}. Ctrl+C stops the demo cleanly.
+=========================================================================
+"""
+
+
+async def main() -> None:
+    transport = MockTransport(
+        {"POST https://api.openai.com/v1/chat/completions": fake_completion}
+    )
+    print(BANNER.format(warn=WARN_AT_USD, error=ERROR_AT_USD), flush=True)
+
+    async with OpenAIChat(transport=transport, monitor=True) as api:
+        api.message("openai cost demo started - watch the $ gauge climb")
+        deadline = time.monotonic() + RUN_FOR_S
+        turn = 0
+        while time.monotonic() < deadline:
+            turn += 1
+            await asyncio.gather(
+                *(
+                    api.chat(
+                        payload={
+                            "model": "gpt-4o-mini",
+                            "messages": [{"role": "user", "content": f"question #{turn}-{i}"}],
+                        }
+                    )
+                    for i in range(random.randint(2, 6))
+                )
+            )
+            print(
+                f"turn {turn:>2}: {OpenAIChat.prompt_tokens:,} in"
+                f" / {OpenAIChat.completion_tokens:,} out tokens so far",
+                flush=True,
+            )
+            await asyncio.sleep(1.0)
+        api.message("openai cost demo finished")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/python/gracy/client.py
+++ b/python/gracy/client.py
@@ -635,24 +635,34 @@ class Gracy:
             return {}
         return dict(self._scheduler.stats())
 
-    def message(self, text: str, *, level: str = "info") -> None:
+    def message(self, text: str, *, level: str = "info", key: str | None = None) -> None:
         """Emit a progress message to the live monitor's messages panel.
 
         Fire-and-forget: works before build() and after aclose(), never raises,
         and costs one deque append when monitoring is disabled. Levels are
         "info" | "warn" | "error" (anything else falls back to "info").
+
+        A ``key`` turns the message into a live gauge: each call REPLACES the
+        previous message with the same key (one panel line updated in place at
+        the tail) instead of appending - made for aggregates recomputed per
+        request, e.g. total payload bytes summed in an after-hook.
         """
         if level not in _MESSAGE_LEVELS:
             level = "info"
+        entry: dict[str, t.Any] = {
+            "id": self._monitor_message_seq + 1,
+            "ts": time.time(),
+            "level": level,
+            "text": str(text),
+        }
+        if key is not None:
+            entry["key"] = str(key)
+            for old in self._monitor_messages:
+                if old.get("key") == entry["key"]:
+                    self._monitor_messages.remove(old)
+                    break
         self._monitor_message_seq += 1
-        self._monitor_messages.append(
-            {
-                "id": self._monitor_message_seq,
-                "ts": time.time(),
-                "level": level,
-                "text": str(text),
-            }
-        )
+        self._monitor_messages.append(entry)
 
     # ------------------------------------------------------------------ sync facade
 

--- a/python/gracy/client.py
+++ b/python/gracy/client.py
@@ -25,7 +25,9 @@ import json as jsonlib
 import logging
 import os
 import threading
+import time
 import typing as t
+from collections import deque
 from contextvars import ContextVar
 
 from gracy._types import UNSET, RequestContext, RequestSpec, Unset
@@ -61,6 +63,11 @@ __all__ = ["Gracy", "GracyNamespace", "SyncGracy"]
 TGracy = t.TypeVar("TGracy", bound="Gracy")
 
 _DEFAULT_TIMEOUT: t.Final = 30.0
+
+# Per-client message buffer republished in every monitor snapshot; the viewer
+# accumulates its own (larger) history, so rotation here never loses messages.
+_MONITOR_MESSAGE_BUFFER: t.Final = 200
+_MESSAGE_LEVELS: t.Final = ("info", "warn", "error")
 
 # Overlay set by api.options(): (partial config or None, priority or None).
 _options_overlay: ContextVar[tuple[GracyConfig | None, int | None] | None] = ContextVar(
@@ -223,6 +230,9 @@ class Gracy:
         self._pipeline: Pipeline | None = None
         self._metrics: MetricsCollector | None = None
         self._monitor_publisher: t.Any = None  # gracy.monitor.MonitorPublisher when enabled
+        # Inert data container (fork-safe): message() may be called pre-build.
+        self._monitor_messages: deque[dict[str, t.Any]] = deque(maxlen=_MONITOR_MESSAGE_BUFFER)
+        self._monitor_message_seq = 0
         self._hooks: list[t.Any] = []
         self._routes: dict[tuple[str | None, str], CompiledRoute] = {}
 
@@ -347,17 +357,16 @@ class Gracy:
 
     async def _start_monitor(self, scheduler: Scheduler, metrics: MetricsCollector) -> None:
         """Spawn the MonitorPublisher (lazy import: zero overhead when disabled)."""
-        import time as _time
-
         from gracy.monitor import MonitorPublisher
 
         publisher = MonitorPublisher(type(self).__name__, current_engine())
+        messages = self._monitor_messages
 
         def get_snapshot() -> dict[str, t.Any]:
             queue = dict(scheduler.stats())
             rows = metrics.monitor_rows(queue.get("throttled_by_uurl") or {})
             requests = sum(row["total"] for row in rows)
-            elapsed = max(_time.time() - publisher.started_at, 0.001)
+            elapsed = max(time.time() - publisher.started_at, 0.001)
             return {
                 "queue": queue,
                 "totals": {
@@ -368,6 +377,7 @@ class Gracy:
                     "req_per_sec": requests / elapsed,
                 },
                 "rows": rows,
+                "messages": list(messages),
             }
 
         await publisher.start(get_snapshot)
@@ -624,6 +634,25 @@ class Gracy:
         if not self._built or self._scheduler is None:
             return {}
         return dict(self._scheduler.stats())
+
+    def message(self, text: str, *, level: str = "info") -> None:
+        """Emit a progress message to the live monitor's messages panel.
+
+        Fire-and-forget: works before build() and after aclose(), never raises,
+        and costs one deque append when monitoring is disabled. Levels are
+        "info" | "warn" | "error" (anything else falls back to "info").
+        """
+        if level not in _MESSAGE_LEVELS:
+            level = "info"
+        self._monitor_message_seq += 1
+        self._monitor_messages.append(
+            {
+                "id": self._monitor_message_seq,
+                "ts": time.time(),
+                "level": level,
+                "text": str(text),
+            }
+        )
 
     # ------------------------------------------------------------------ sync facade
 

--- a/python/gracy/monitor/viewer.py
+++ b/python/gracy/monitor/viewer.py
@@ -3,7 +3,8 @@
 Reads the snapshot files published by running Gracy clients (schema 1, one
 JSON file per client instance in the monitor spool dir) and renders a
 full-screen rich dashboard: header, big-number tiles, sparkline activity
-chart, per-endpoint table and a per-source footer.
+chart, per-endpoint table, client-emitted messages (scrollable with ↑/↓,
+shown only once a client calls ``message()``) and a per-source footer.
 
 Run it with ``python -m gracy.monitor``. Requires the ``rich`` extra.
 """
@@ -29,6 +30,8 @@ LIVE_MAX_AGE_S: t.Final = 3.0  # newer than this (and not closed) -> LIVE
 STALE_MAX_AGE_S: t.Final = 30.0  # older than this -> ignored + cleaned up
 CLOSED_TILE_GRACE_S: t.Final = 5.0  # closed sources leave the tiles after this
 MAX_TABLE_ROWS: t.Final = 12
+MAX_MESSAGES: t.Final = 1000  # viewer-side history (outlives the clients' own buffers)
+MESSAGE_TAIL_ROWS: t.Final = 3  # visible window; panel shrinks below this when fewer exist
 
 _BLOCKS: t.Final = "▁▂▃▄▅▆▇█"
 
@@ -41,6 +44,7 @@ _C_ABORT: t.Final = "red"
 _C_RETRY: t.Final = "dark_orange"
 _C_REPLAY: t.Final = "blue"
 _C_RATE: t.Final = "green"
+_C_MESSAGE_LEVELS: t.Final = {"info": "white", "warn": "yellow", "error": "red"}
 
 
 def default_spool_dir() -> str:
@@ -99,6 +103,11 @@ class Source:
     @property
     def totals(self) -> dict[str, t.Any]:
         return self.data.get("totals") or {}
+
+    @property
+    def messages(self) -> list[dict[str, t.Any]]:
+        raw = self.data.get("messages")
+        return raw if isinstance(raw, list) else []
 
 
 def read_sources(directory: str, now: float | None = None) -> list[Source]:
@@ -243,6 +252,80 @@ def aggregate_rows(sources: list[Source]) -> list[dict[str, t.Any]]:
         row["p95_latency"] = row.pop("_p95_weight") / total
     rows.sort(key=lambda r: (-r["total"], r["uurl"]))
     return rows
+
+
+# ------------------------------------------------------------------ messages
+
+
+def _safe_float(value: t.Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+class MessageLog:
+    """Cross-frame accumulator for messages emitted via ``client.message()``.
+
+    Every snapshot re-sends the client's current (rotating) message buffer, so
+    entries are deduped by (spool file, per-client message id) and retained
+    here even after they rotate out of the client's own buffer: scrolling back
+    never loses history, up to MAX_MESSAGES.
+    """
+
+    def __init__(self, maxlen: int = MAX_MESSAGES) -> None:
+        self._maxlen = maxlen
+        self._entries: dict[tuple[str, int], dict[str, t.Any]] = {}
+        self._clients: set[str] = set()
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    @property
+    def multi_client(self) -> bool:
+        return len(self._clients) > 1
+
+    def ingest(self, sources: list[Source]) -> None:
+        fresh: list[tuple[tuple[str, int], dict[str, t.Any]]] = []
+        for src in sources:
+            for msg in src.messages:
+                if not isinstance(msg, dict):
+                    continue
+                try:
+                    key = (src.path, int(msg["id"]))
+                except (KeyError, TypeError, ValueError):
+                    continue
+                if key in self._entries:
+                    continue
+                fresh.append(
+                    (
+                        key,
+                        {
+                            "ts": _safe_float(msg.get("ts")),
+                            "level": str(msg.get("level", "info")),
+                            "text": str(msg.get("text", "")),
+                            "client": src.client,
+                        },
+                    )
+                )
+        fresh.sort(key=lambda item: item[1]["ts"])  # interleave multi-source bursts by time
+        for key, entry in fresh:
+            self._entries[key] = entry
+            self._clients.add(entry["client"])
+        while len(self._entries) > self._maxlen:
+            del self._entries[next(iter(self._entries))]
+
+    def window(self, offset: int, rows: int) -> tuple[list[dict[str, t.Any]], int, int]:
+        """The `rows` entries ending `offset` back from the tail.
+
+        Returns (entries, start_index, total); offset is clamped so the window
+        never runs past either end.
+        """
+        entries = list(self._entries.values())
+        total = len(entries)
+        offset = max(0, min(offset, total - rows)) if total > rows else 0
+        end = total - offset
+        return entries[max(0, end - rows) : end], max(0, end - rows), total
 
 
 # ------------------------------------------------------------------ rendering
@@ -443,6 +526,52 @@ def _count_text(value: t.Any, color: str) -> RenderableType:
     return Text(str(count), style=color if count else "dim")
 
 
+def _messages_panel(log: MessageLog, offset: int) -> RenderableType | None:
+    """Client-emitted messages: hidden until the first one arrives, then grows
+    one line per message up to MESSAGE_TAIL_ROWS and follows the tail unless
+    scrolled back (offset > 0)."""
+    from rich import box
+    from rich.console import Group
+    from rich.panel import Panel
+    from rich.text import Text
+
+    entries, start, total = log.window(offset, MESSAGE_TAIL_ROWS)
+    if not entries:
+        return None
+
+    lines: list[Text] = []
+    for entry in entries:
+        level = entry["level"]
+        color = _C_MESSAGE_LEVELS.get(level, _C_MESSAGE_LEVELS["info"])
+        line = Text(no_wrap=True, overflow="ellipsis")
+        ts = entry["ts"]
+        stamp = time.strftime("%H:%M:%S", time.localtime(ts)) if ts > 0 else "--:--:--"
+        line.append(f"{stamp} ", style="dim")
+        line.append("• ", style=color)
+        if log.multi_client:
+            line.append(f"{entry['client']} ", style="dim")
+        line.append(entry["text"], style="" if level == "info" else color)
+        lines.append(line)
+
+    scrolled = start + len(entries) < total
+    if scrolled:
+        title = f"messages · {start + 1}–{start + len(entries)}/{total}"
+        subtitle = "↑/↓ scroll · esc live"
+    else:
+        title = f"messages · {total}"
+        subtitle = "↑ older" if total > MESSAGE_TAIL_ROWS else None
+    return Panel(
+        Group(*lines),
+        title=title,
+        title_align="left",
+        subtitle=Text(subtitle, style="dim") if subtitle else None,
+        subtitle_align="right",
+        box=box.ROUNDED,
+        border_style="dim",
+        padding=(0, 1),
+    )
+
+
 def _sources_footer(sources: list[Source]) -> RenderableType:
     from rich.console import Group
     from rich.text import Text
@@ -497,6 +626,8 @@ def _empty_state(directory: str) -> RenderableType:
 def build_dashboard(
     directory: str,
     history: t.MutableSequence[HistoryPoint],
+    messages: MessageLog,
+    msg_offset: int,
     window: int,
     width: int,
 ) -> RenderableType:
@@ -512,14 +643,121 @@ def build_dashboard(
     agg = aggregate(sources)
     history.append((now, agg.in_flight, agg.pending, agg.req_per_sec))
     rows = aggregate_rows(sources)
+    messages.ingest(sources)
 
-    return Group(
+    panels = [
         _header(sources, agg, now),
         _tiles_row(agg),
         _chart(history, window, width, agg),
         _endpoint_table(rows, width),
-        _sources_footer(sources),
-    )
+    ]
+    messages_panel = _messages_panel(messages, msg_offset)
+    if messages_panel is not None:
+        panels.append(messages_panel)
+    panels.append(_sources_footer(sources))
+    return Group(*panels)
+
+
+# ------------------------------------------------------------------ keyboard
+
+_KEY_SEQUENCES: t.Final = {
+    b"[A": "up",
+    b"[B": "down",
+    b"[5~": "pgup",
+    b"[6~": "pgdn",
+    b"[H": "home",
+    b"[F": "end",
+    b"OH": "home",
+    b"OF": "end",
+}
+
+
+def decode_keys(data: bytes) -> list[str]:
+    """Map raw terminal input to key names ('up', 'down', 'pgup', 'pgdn',
+    'home', 'end', 'esc'); vi keys j/k work too. Unknown bytes are ignored."""
+    keys: list[str] = []
+    i = 0
+    while i < len(data):
+        byte = data[i : i + 1]
+        if byte == b"\x1b":
+            for seq, name in _KEY_SEQUENCES.items():
+                if data.startswith(seq, i + 1):
+                    keys.append(name)
+                    i += 1 + len(seq)
+                    break
+            else:
+                keys.append("esc")
+                i += 1
+            continue
+        if byte == b"k":
+            keys.append("up")
+        elif byte == b"j":
+            keys.append("down")
+        i += 1
+    return keys
+
+
+def scroll_offset(key: str, offset: int, total: int) -> int:
+    """Next messages-panel scroll offset (0 = follow the tail live)."""
+    top = max(0, total - MESSAGE_TAIL_ROWS)
+    if key == "up":
+        offset += 1
+    elif key == "down":
+        offset -= 1
+    elif key == "pgup":
+        offset += MESSAGE_TAIL_ROWS
+    elif key == "pgdn":
+        offset -= MESSAGE_TAIL_ROWS
+    elif key == "home":
+        offset = top
+    elif key in ("end", "esc"):
+        offset = 0
+    return max(0, min(offset, top))
+
+
+class _KeyPoller:
+    """Non-blocking key reader for message scrolling (POSIX terminals only).
+
+    Inside the context stdin sits in cbreak mode (ISIG stays on, so ctrl+c
+    still quits); ``wait(timeout)`` doubles as the frame sleep and returns any
+    keys pressed. On Windows or without a TTY it degrades to a plain sleep -
+    the dashboard renders normally, only scrolling is unavailable.
+    """
+
+    def __init__(self) -> None:
+        self._fd: int | None = None
+        self._saved: t.Any = None
+
+    def __enter__(self) -> _KeyPoller:
+        try:
+            import sys
+            import termios
+            import tty
+
+            if sys.stdin.isatty():
+                self._fd = sys.stdin.fileno()
+                self._saved = termios.tcgetattr(self._fd)
+                tty.setcbreak(self._fd)
+        except Exception:
+            self._fd = None
+        return self
+
+    def __exit__(self, *exc_info: t.Any) -> None:
+        if self._fd is not None and self._saved is not None:
+            import termios
+
+            termios.tcsetattr(self._fd, termios.TCSADRAIN, self._saved)
+
+    def wait(self, timeout: float) -> list[str]:
+        if self._fd is None:
+            time.sleep(timeout)
+            return []
+        import select
+
+        ready, _, _ = select.select([self._fd], [], [], timeout)
+        if not ready:
+            return []
+        return decode_keys(os.read(self._fd, 64))
 
 
 # ------------------------------------------------------------------ entrypoint
@@ -542,16 +780,21 @@ def run(directory: str, fps: float, window: int, once: bool) -> int:
     fps = max(0.2, fps)
     max_points = max(int(window * fps) + 8, 64)
     history: deque[HistoryPoint] = deque(maxlen=max_points)
+    messages = MessageLog()
 
     if once:
-        console.print(build_dashboard(directory, history, window, console.width))
+        console.print(build_dashboard(directory, history, messages, 0, window, console.width))
         return 0
 
+    msg_offset = 0
     try:
-        with Live(console=console, screen=True, refresh_per_second=fps) as live:
+        with _KeyPoller() as keys, Live(console=console, screen=True, refresh_per_second=fps) as live:
             while True:
-                live.update(build_dashboard(directory, history, window, console.width))
-                time.sleep(1.0 / fps)
+                live.update(
+                    build_dashboard(directory, history, messages, msg_offset, window, console.width)
+                )
+                for key in keys.wait(1.0 / fps):
+                    msg_offset = scroll_offset(key, msg_offset, len(messages))
     except KeyboardInterrupt:
         pass
     return 0

--- a/python/gracy/monitor/viewer.py
+++ b/python/gracy/monitor/viewer.py
@@ -271,11 +271,15 @@ class MessageLog:
     entries are deduped by (spool file, per-client message id) and retained
     here even after they rotate out of the client's own buffer: scrolling back
     never loses history, up to MAX_MESSAGES.
+
+    Keyed messages (``client.message(..., key=...)``) are live gauges instead:
+    deduped by (spool file, key), a changed id replaces the old text and moves
+    the single entry to the tail - updates never pile up in the history.
     """
 
     def __init__(self, maxlen: int = MAX_MESSAGES) -> None:
         self._maxlen = maxlen
-        self._entries: dict[tuple[str, int], dict[str, t.Any]] = {}
+        self._entries: dict[tuple[str, str], dict[str, t.Any]] = {}
         self._clients: set[str] = set()
 
     def __len__(self) -> int:
@@ -286,21 +290,27 @@ class MessageLog:
         return len(self._clients) > 1
 
     def ingest(self, sources: list[Source]) -> None:
-        fresh: list[tuple[tuple[str, int], dict[str, t.Any]]] = []
+        fresh: list[tuple[tuple[str, str], dict[str, t.Any]]] = []
         for src in sources:
             for msg in src.messages:
                 if not isinstance(msg, dict):
                     continue
                 try:
-                    key = (src.path, int(msg["id"]))
+                    msg_id = int(msg["id"])
                 except (KeyError, TypeError, ValueError):
                     continue
-                if key in self._entries:
-                    continue
+                gauge = msg.get("key")
+                key = (src.path, f"k:{gauge}" if gauge else f"i:{msg_id}")
+                existing = self._entries.get(key)
+                if existing is not None:
+                    if existing["id"] == msg_id:
+                        continue  # plain re-send of a known entry
+                    del self._entries[key]  # keyed gauge update: re-append at the tail
                 fresh.append(
                     (
                         key,
                         {
+                            "id": msg_id,
                             "ts": _safe_float(msg.get("ts")),
                             "level": str(msg.get("level", "info")),
                             "text": str(msg.get("text", "")),

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -195,6 +195,76 @@ async def test_messages_land_in_snapshot(spool: Path):
     api.message("after close never raises")  # fire-and-forget even when closed
 
 
+async def test_keyed_message_replaces_previous_in_buffer(spool: Path):
+    async with MonitoredAPI(transport=ok_transport(), monitor=True) as api:
+        api.message("start")
+        api.message("payload: 1 KiB", key="payload")
+        api.message("middle")
+        api.message("payload: 2 KiB", key="payload")  # replaces, re-appended at the tail
+
+        await wait_for(lambda: bool(spool_files(spool)) and len(read_snapshot(spool).get("messages", [])) == 3)
+        msgs = read_snapshot(spool)["messages"]
+
+        assert [m["text"] for m in msgs] == ["start", "middle", "payload: 2 KiB"]
+        assert msgs[-1]["key"] == "payload"
+        assert msgs[-1]["id"] == 4  # ids keep advancing so the viewer sees the update
+        assert "key" not in msgs[0]  # plain messages stay lean
+
+
+async def test_after_hook_aggregates_usage_into_one_keyed_gauge(spool: Path):
+    """The docs use case: an after-hook sums token usage from real-shape
+    OpenAI chat.completion payloads and keeps ONE cost line on the monitor."""
+
+    completion = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 100, "completion_tokens": 40, "total_tokens": 140},
+    }
+
+    class CostTrackedAPI(Gracy):
+        base_url = BASE
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        @get("/thing/{name}")
+        async def get_thing(self, name: str) -> dict: ...
+
+        async def after(self, context: t.Any, result: t.Any, retry_state: t.Any) -> None:
+            from gracy import Response
+
+            if not (isinstance(result, Response) and result.is_success):
+                return
+            usage = result.json().get("usage") or {}
+            cls = type(self)
+            cls.prompt_tokens += int(usage.get("prompt_tokens", 0))
+            cls.completion_tokens += int(usage.get("completion_tokens", 0))
+            self.message(
+                f"{cls.prompt_tokens} in / {cls.completion_tokens} out",
+                key="cost",
+            )
+
+    transport = MockTransport({f"GET {BASE}/thing/*": completion})
+    async with CostTrackedAPI(transport=transport, monitor=True) as api:
+        for name in ("a", "b", "c"):
+            await api.get_thing(name)
+
+        await wait_for(
+            lambda: bool(spool_files(spool))
+            and [m["text"] for m in read_snapshot(spool).get("messages", [])] == ["300 in / 120 out"]
+        )
+        msgs = read_snapshot(spool)["messages"]
+        assert len(msgs) == 1  # 3 requests -> ONE aggregated line, not three
+        assert msgs[0]["key"] == "cost"
+
+
 async def test_no_messages_key_is_empty_list(spool: Path):
     async with MonitoredAPI(transport=ok_transport(), monitor=True):
         await wait_for(lambda: bool(spool_files(spool)), timeout=0.6)

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -168,6 +168,39 @@ async def test_env_var_enables_monitor(spool: Path, monkeypatch: pytest.MonkeyPa
     assert read_snapshot(spool)["closed"] is True
 
 
+# --------------------------------------------------------------------- messages
+
+
+async def test_messages_land_in_snapshot(spool: Path):
+    api = MonitoredAPI(transport=ok_transport(), monitor=True)
+    api.message("queued before build")  # pre-build works (inert buffer)
+    async with api:
+        api.message("base resources fetched")
+        api.message("rate limit near ceiling", level="warn")
+        api.message("kaboom", level="bogus")  # unknown level falls back to info
+
+        await wait_for(lambda: bool(spool_files(spool)) and len(read_snapshot(spool).get("messages", [])) == 4)
+        msgs = read_snapshot(spool)["messages"]
+
+        assert [m["text"] for m in msgs] == [
+            "queued before build",
+            "base resources fetched",
+            "rate limit near ceiling",
+            "kaboom",
+        ]
+        assert [m["level"] for m in msgs] == ["info", "info", "warn", "info"]
+        assert [m["id"] for m in msgs] == [1, 2, 3, 4]  # per-client monotonic ids
+        assert all(isinstance(m["ts"], float) for m in msgs)
+
+    api.message("after close never raises")  # fire-and-forget even when closed
+
+
+async def test_no_messages_key_is_empty_list(spool: Path):
+    async with MonitoredAPI(transport=ok_transport(), monitor=True):
+        await wait_for(lambda: bool(spool_files(spool)), timeout=0.6)
+        assert read_snapshot(spool)["messages"] == []
+
+
 # --------------------------------------------------------------------- resilience
 
 

--- a/tests/test_monitor_viewer.py
+++ b/tests/test_monitor_viewer.py
@@ -15,7 +15,7 @@ import time
 import typing as t
 from pathlib import Path
 
-from gracy.monitor.viewer import spark
+from gracy.monitor.viewer import MessageLog, Source, decode_keys, scroll_offset, spark
 
 # ---------------------------------------------------------------- helpers
 
@@ -30,8 +30,10 @@ def _snapshot(
     rows: list[dict[str, t.Any]] | None = None,
     queue: dict[str, t.Any] | None = None,
     totals: dict[str, t.Any] | None = None,
+    messages: list[dict[str, t.Any]] | None = None,
 ) -> dict[str, t.Any]:
     return {
+        "messages": messages or [],
         "schema": 1,
         "ts": ts,
         "started_at": ts - 120.0,
@@ -186,6 +188,142 @@ def test_once_empty_dir_shows_how_to_enable(tmp_path: Path) -> None:
     # so only check the label and the path's tail component)
     assert "watching" in out
     assert tmp_path.name[-12:] in out.replace("\n", "").replace("│", "").replace(" ", "")
+
+
+# ---------------------------------------------------------------- MessageLog
+
+
+def _msg_source(path: str, client: str, msgs: list[dict[str, t.Any]]) -> Source:
+    return Source(path=path, data={"client": client, "messages": msgs}, age=0.0)
+
+
+def _msg(mid: int, text: str, *, ts: float = 0.0, level: str = "info") -> dict[str, t.Any]:
+    return {"id": mid, "ts": ts or float(mid), "level": level, "text": text}
+
+
+def test_messagelog_dedupes_resent_buffers() -> None:
+    log = MessageLog()
+    src = _msg_source("a.json", "API", [_msg(1, "one"), _msg(2, "two")])
+    log.ingest([src])
+    log.ingest([src])  # snapshots re-send the whole buffer every frame
+    assert len(log) == 2
+
+
+def test_messagelog_retains_entries_beyond_client_buffer_rotation() -> None:
+    log = MessageLog()
+    log.ingest([_msg_source("a.json", "API", [_msg(1, "one"), _msg(2, "two")])])
+    # client buffer rotated: id 1 is gone from the snapshot, ids 3-4 are new
+    log.ingest([_msg_source("a.json", "API", [_msg(2, "two"), _msg(3, "three"), _msg(4, "four")])])
+    entries, start, total = log.window(0, 3)
+    assert total == 4  # "one" was never lost
+    assert [e["text"] for e in entries] == ["two", "three", "four"]
+    assert start == 1
+
+
+def test_messagelog_window_clamps_offset_and_shrinks_below_rows() -> None:
+    log = MessageLog()
+    log.ingest([_msg_source("a.json", "API", [_msg(i, f"m{i}") for i in range(1, 6)])])
+    entries, start, total = log.window(99, 3)  # over-scrolled: clamp to oldest window
+    assert (start, total) == (0, 5)
+    assert [e["text"] for e in entries] == ["m1", "m2", "m3"]
+
+    small = MessageLog()
+    small.ingest([_msg_source("a.json", "API", [_msg(1, "only")])])
+    entries, start, total = small.window(0, 3)
+    assert [e["text"] for e in entries] == ["only"]  # 1 line, not padded to 3
+    assert (start, total) == (0, 1)
+
+
+def test_messagelog_interleaves_sources_by_ts_and_caps_history() -> None:
+    log = MessageLog(maxlen=3)
+    log.ingest(
+        [
+            _msg_source("a.json", "A", [_msg(1, "a-late", ts=20.0)]),
+            _msg_source("b.json", "B", [_msg(1, "b-early", ts=10.0)]),
+        ]
+    )
+    entries, _, _ = log.window(0, 3)
+    assert [e["text"] for e in entries] == ["b-early", "a-late"]
+    assert log.multi_client
+
+    log.ingest([_msg_source("a.json", "A", [_msg(2, "x", ts=30.0), _msg(3, "y", ts=40.0)])])
+    entries, _, total = log.window(0, 3)
+    assert total == 3  # capped: oldest evicted
+    assert [e["text"] for e in entries] == ["a-late", "x", "y"]
+
+
+def test_messagelog_skips_malformed_entries() -> None:
+    log = MessageLog()
+    log.ingest(
+        [
+            _msg_source(
+                "a.json",
+                "API",
+                [{"text": "no id"}, {"id": "NaN", "text": "bad id"}, "not-a-dict", _msg(7, "ok")],  # type: ignore[list-item]
+            )
+        ]
+    )
+    entries, _, total = log.window(0, 3)
+    assert total == 1
+    assert entries[0]["text"] == "ok"
+
+
+# ---------------------------------------------------------------- keyboard
+
+
+def test_decode_keys_arrows_pages_and_vi() -> None:
+    assert decode_keys(b"\x1b[A\x1b[B") == ["up", "down"]
+    assert decode_keys(b"\x1b[5~\x1b[6~") == ["pgup", "pgdn"]
+    assert decode_keys(b"\x1b[H\x1b[F\x1bOF") == ["home", "end", "end"]
+    assert decode_keys(b"kj") == ["up", "down"]
+    assert decode_keys(b"\x1b") == ["esc"]
+    assert decode_keys(b"zzz") == []
+
+
+def test_scroll_offset_clamps_and_resets() -> None:
+    total = 10  # top offset = 7 (window of 3)
+    assert scroll_offset("up", 0, total) == 1
+    assert scroll_offset("up", 7, total) == 7  # already at the oldest window
+    assert scroll_offset("down", 1, total) == 0
+    assert scroll_offset("down", 0, total) == 0
+    assert scroll_offset("pgup", 0, total) == 3
+    assert scroll_offset("home", 0, total) == 7
+    assert scroll_offset("end", 5, total) == 0
+    assert scroll_offset("esc", 5, total) == 0
+    assert scroll_offset("up", 0, 2) == 0  # fewer messages than the window: no scrolling
+
+
+# ---------------------------------------------------------------- messages panel (--once)
+
+
+def test_once_renders_messages_panel_when_present(tmp_path: Path) -> None:
+    now = time.time()
+    _write(
+        tmp_path,
+        "555-MsgAPI-aaaa1111.json",
+        _snapshot(
+            client="MsgAPI",
+            pid=555,
+            ts=now,
+            messages=[
+                {"id": 1, "ts": now - 5, "level": "info", "text": "base resources fetched"},
+                {"id": 2, "ts": now - 1, "level": "warn", "text": "rate limit near ceiling"},
+            ],
+        ),
+    )
+    result = _render_once(tmp_path)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "messages · 2" in out
+    assert "base resources fetched" in out
+    assert "rate limit near ceiling" in out
+
+
+def test_once_hides_messages_panel_when_empty(tmp_path: Path) -> None:
+    _write(tmp_path, "666-QuietAPI-bbbb2222.json", _snapshot(client="QuietAPI", pid=666, ts=time.time()))
+    result = _render_once(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "messages" not in result.stdout
 
 
 def test_once_skips_corrupt_files(tmp_path: Path) -> None:

--- a/tests/test_monitor_viewer.py
+++ b/tests/test_monitor_viewer.py
@@ -197,8 +197,13 @@ def _msg_source(path: str, client: str, msgs: list[dict[str, t.Any]]) -> Source:
     return Source(path=path, data={"client": client, "messages": msgs}, age=0.0)
 
 
-def _msg(mid: int, text: str, *, ts: float = 0.0, level: str = "info") -> dict[str, t.Any]:
-    return {"id": mid, "ts": ts or float(mid), "level": level, "text": text}
+def _msg(
+    mid: int, text: str, *, ts: float = 0.0, level: str = "info", key: str | None = None
+) -> dict[str, t.Any]:
+    msg: dict[str, t.Any] = {"id": mid, "ts": ts or float(mid), "level": level, "text": text}
+    if key is not None:
+        msg["key"] = key
+    return msg
 
 
 def test_messagelog_dedupes_resent_buffers() -> None:
@@ -250,6 +255,50 @@ def test_messagelog_interleaves_sources_by_ts_and_caps_history() -> None:
     entries, _, total = log.window(0, 3)
     assert total == 3  # capped: oldest evicted
     assert [e["text"] for e in entries] == ["a-late", "x", "y"]
+
+
+def test_messagelog_keyed_gauge_updates_in_place_at_the_tail() -> None:
+    log = MessageLog()
+    log.ingest(
+        [_msg_source("a.json", "API", [_msg(1, "start"), _msg(2, "1 KiB", key="payload")])]
+    )
+    # next snapshot: gauge updated (new id, same key) + one new plain message
+    log.ingest(
+        [
+            _msg_source(
+                "a.json",
+                "API",
+                [_msg(1, "start"), _msg(3, "mid"), _msg(4, "2 KiB", key="payload")],
+            )
+        ]
+    )
+    entries, _, total = log.window(0, 5)
+    assert total == 2 + 1  # the gauge never piles up in the history
+    assert [e["text"] for e in entries] == ["start", "mid", "2 KiB"]
+
+    # a re-send with no change keeps order and count stable
+    log.ingest(
+        [
+            _msg_source(
+                "a.json",
+                "API",
+                [_msg(1, "start"), _msg(3, "mid"), _msg(4, "2 KiB", key="payload")],
+            )
+        ]
+    )
+    entries, _, total = log.window(0, 5)
+    assert total == 3
+    assert [e["text"] for e in entries] == ["start", "mid", "2 KiB"]
+
+
+def test_messagelog_key_and_id_namespaces_never_collide() -> None:
+    log = MessageLog()
+    log.ingest(
+        [_msg_source("a.json", "API", [_msg(5, "plain five"), _msg(6, "gauge", key="5")])]
+    )
+    entries, _, total = log.window(0, 5)
+    assert total == 2  # key "5" does not clash with id 5
+    assert [e["text"] for e in entries] == ["plain five", "gauge"]
 
 
 def test_messagelog_skips_malformed_entries() -> None:


### PR DESCRIPTION
## What

User code can now emit explicit progress messages that show up on the live monitor:

```python
api.message("base resources fetched")
api.message("rate limit near ceiling", level="warn")   # info | warn | error
```

The dashboard gets a `messages` panel between the endpoints table and the footer:
- **Hidden until the first message arrives**, then grows one line per message up to 3 (never pads empty lines).
- Always follows the tail (last 3) — scroll back with **↑/↓, PgUp/PgDn, Home** (vi `j`/`k` work too); **End/Esc** returns to the live tail.
- **History is never lost**: the viewer accumulates up to 1000 messages, deduped across snapshot re-sends, outliving each client's own 200-entry rotating buffer.
- Levels color the line: `warn` yellow, `error` red, `info` plain; timestamps dimmed; client name shown when multiple sources emit.

## How

- **Client** (`python/gracy/client.py`): `Gracy.message()` is fire-and-forget — never raises, works before `build()` and after `aclose()`, costs one deque append when monitoring is off. Messages ride the existing schema-1 snapshot as a new `messages` key (no transport change). `SyncGracy` proxies it automatically.
- **Viewer** (`python/gracy/monitor/viewer.py`): new `MessageLog` accumulator (dedupe by spool file + per-client id, multi-source interleave by ts), `_messages_panel`, and a `_KeyPoller` that puts stdin in cbreak mode on POSIX TTYs (ctrl+c still quits) and degrades to render-only on Windows/non-TTY.
- **Demo** (`examples/v2_monitor_demo.py`): emits one message per wave so the panel + scrolling can be tried immediately.

## Tests

15 new tests (`test_monitor_publisher.py`, `test_monitor_viewer.py`): snapshot shape/ids/levels, pre-build + post-close emission, dedupe, retention beyond client buffer rotation, window clamping/shrinking, multi-source interleave, history cap, malformed-entry resilience, key decoding, scroll clamping, and `--once` rendering (panel present with messages, absent without).

Full suite: **475 passed, 1 skipped**. The one failure (`test_once_renders_live_stale_and_closed_sources`) is **pre-existing on gracy-v2** (reproduced on a clean stash; looks environment/rich-version sensitive, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqDW4smP4Rz4YiRGFNQNUJ


---

## Update: keyed messages (live gauges) + after-hook cost tracking

`message(key=...)` turns a message into a **live gauge**: each call replaces the previous message with the same key — one panel line updated in place at the tail, never flooding the history. Built for aggregates recomputed per request from an `after` hook (which already existed; the client's own `after` override can call `self.message(...)` directly).

```python
async def after(self, context, result, retry_state) -> None:
    if isinstance(result, gracy.Response) and result.is_success:
        usage = result.json().get("usage") or {}
        cls = type(self)
        cls.prompt_tokens += usage.get("prompt_tokens", 0)
        cls.completion_tokens += usage.get("completion_tokens", 0)
        cost = (cls.prompt_tokens * 2.50 + cls.completion_tokens * 10.00) / 1_000_000
        self.message(f"openai: {cls.prompt_tokens:,} in / {cls.completion_tokens:,} out tok · est. ${cost:.4f}",
                     level="warn" if cost >= 0.05 else "info", key="openai-cost")
```

- **New demo** `examples/v2_openai_cost_demo.py`: mocks the OpenAI chat completions API with real-shape `chat.completion` payloads (`usage` block included — zero credits, no API key) and drives a session-cost gauge that escalates info → warn → error. Verified end-to-end: dozens of requests render as ONE gauge line (`messages · 2`).
- **README**: new "Messages: your code talks on the dashboard" section documenting `message()`, scrolling, and the keyed-gauge/cost-tracking use case.
- Viewer dedupes gauges by (spool file, key) in prefixed namespaces (key `"5"` can't collide with id `5`); unchanged re-sends are no-ops.
- +5 tests (35 total for the monitor): buffer replacement, gauge update-at-tail, namespace collision, and the full after-hook aggregation scenario. Suite: **610 passed, 2 skipped** (same pre-existing baseline failure deselected).
